### PR TITLE
feat: adds standardized response for sucess and error

### DIFF
--- a/infrastructure/src/main/java/postech/soat/tech/challenge/api/config/GlobalExceptionHandler.java
+++ b/infrastructure/src/main/java/postech/soat/tech/challenge/api/config/GlobalExceptionHandler.java
@@ -1,0 +1,22 @@
+package postech.soat.tech.challenge.api.config;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import postech.soat.tech.challenge.api.response.ApiErrorResponse;
+import postech.soat.tech.challenge.api.response.ApiResponse;
+
+import java.util.List;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(RuntimeException.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public ApiResponse handleValidationExceptions(RuntimeException ex) {
+        var errorList = List.of(new ApiErrorResponse("An unknown error occurred."));
+
+        return new ApiResponse<>(errorList);
+    }
+}

--- a/infrastructure/src/main/java/postech/soat/tech/challenge/api/controller/SampleController.java
+++ b/infrastructure/src/main/java/postech/soat/tech/challenge/api/controller/SampleController.java
@@ -1,0 +1,19 @@
+package postech.soat.tech.challenge.api.controller;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import postech.soat.tech.challenge.api.response.ApiResponse;
+
+@RestController
+@RequestMapping("/api/sample")
+public class SampleController {
+
+    @GetMapping
+    @ResponseStatus(HttpStatus.OK)
+    public ApiResponse<String> sampleEndpoint() {
+        return new ApiResponse<>("Hello, World!");
+    }
+}

--- a/infrastructure/src/main/java/postech/soat/tech/challenge/api/response/ApiErrorResponse.java
+++ b/infrastructure/src/main/java/postech/soat/tech/challenge/api/response/ApiErrorResponse.java
@@ -1,0 +1,10 @@
+package postech.soat.tech.challenge.api.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class ApiErrorResponse {
+    private String message;
+}

--- a/infrastructure/src/main/java/postech/soat/tech/challenge/api/response/ApiResponse.java
+++ b/infrastructure/src/main/java/postech/soat/tech/challenge/api/response/ApiResponse.java
@@ -1,0 +1,30 @@
+package postech.soat.tech.challenge.api.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class ApiResponse<T> {
+    private final ResponseStatus status;
+    private final T data;
+    private final List<ApiErrorResponse> errors;
+    private final LocalDateTime timestamp;
+
+    public ApiResponse(T data) {
+        this.status = ResponseStatus.SUCCESS;
+        this.timestamp = LocalDateTime.now();
+        this.data = data;
+        this.errors = null;
+    }
+
+    public ApiResponse(List<ApiErrorResponse> errors) {
+        this.status = ResponseStatus.ERROR;
+        this.timestamp = LocalDateTime.now();
+        this.data = null;
+        this.errors = errors;
+    }
+}

--- a/infrastructure/src/main/java/postech/soat/tech/challenge/api/response/ResponseStatus.java
+++ b/infrastructure/src/main/java/postech/soat/tech/challenge/api/response/ResponseStatus.java
@@ -1,0 +1,6 @@
+package postech.soat.tech.challenge.api.response;
+
+public enum ResponseStatus {
+    SUCCESS,
+    ERROR
+}


### PR DESCRIPTION
## Description

Adding a standardized response for every endpoint in the API. I also added a sample endpoint that demonstrates how to set the response in the case of success, and a generic error handler for runtime exceptions to demonstrate how to use it in case of errors.

Example of a success response:
```json
{
    "status": "SUCCESS",
    "data": "Hello, World!",
    "timestamp": "2024-05-18T16:37:17.415778172"
}
```

Example of an error response:
```json
{
    "status": "ERROR",
    "errors": [
        {
            "message": "An unknown error occurred."
        }
    ],
    "timestamp": "2024-05-18T16:39:15.612668548"
}
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Since there are no real endpoints yet, I did not saw the need to write a test just to check the schema of the response by itself. 

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
